### PR TITLE
Module optimization

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# http://editorconfig.org/
+
+[*.{pl,pm,t,pod}]
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,5 +1,3 @@
-Audio-StreamGenerator-0.02.tar.gz
-Audio-StreamGenerator-0.04.tar.gz
 lib/Audio/StreamGenerator.pm
 LICENSE
 Makefile.PL

--- a/lib/Audio/StreamGenerator.pm
+++ b/lib/Audio/StreamGenerator.pm
@@ -58,9 +58,13 @@ sub stream {
     my @channels;
     push @channels, $_ for 0 ... ( $self->{channels_amount} - 1 );
 
+    my $eof = undef;
+
     while (1) {
 
-        if ( eof( $self->{source} ) || $self->{skip} ) {
+        $eof = eof( $self->{source} ) unless defined $eof;
+        if ( $eof || $self->{skip} ) {
+            $eof = undef;
 
             if ( $self->{skip} ) {
                 $logger->info('shortening buffer for skip...');
@@ -89,6 +93,9 @@ sub stream {
                 $logger->info('mixing');
             }
 
+            # make the buffer mixable
+            $self->{buffer} = [map { $self->_unpack_sample($_) } @{$self->{buffer}}];
+
             my $index                  = 0;
             my $last_loud_sample_index = -1;
             my $threshold              = $maxint * $self->{max_vol_before_mix_fraction};
@@ -112,7 +119,7 @@ sub stream {
 
             my @new_buffer;
             while ( @new_buffer < @{ $self->{buffer} } ) {
-                my $sample = $self->_get_sample();
+                my $sample = $self->_unpack_sample($self->_get_sample);
                 last if !defined($sample);
                 push( @new_buffer, $sample );
             }
@@ -170,17 +177,13 @@ sub stream {
 
             my $channel = 0;
 
-            foreach my $channel (@channels) {
-                $logger->info("channel $channel needs volume adjustment")
-                    if ( $max[$channel] > $maxint );
-            }
+            # Volume adjustment
+            foreach my $channel ( grep { $max[$channel] > $maxint } @channels ) {
+                $logger->info("channel $channel needs volume adjustment");
 
-            foreach my $sample ( @{ $self->{buffer} } ) {
-                for my $channel (@channels) {
-                    if ( $max[$channel] > $maxint ) {
-                        $sample->[$channel] =
-                            ( $sample->[$channel] / $max[$channel] ) * $maxint;
-                    }
+                foreach my $sample ( @{ $self->{buffer} } ) {
+                    $sample->[$channel] =
+                        ( $sample->[$channel] / $max[$channel] ) * $maxint;
                 }
             }
 
@@ -190,10 +193,13 @@ sub stream {
 
         while ( @{ $self->{buffer} } < ( $self->{normal_fade_seconds} * $self->{sample_rate} ) ) {
             my $sample = $self->_get_sample();
-            last if !defined($sample);
+            if (!defined($sample)) {
+                $eof = 1;
+                last;
+            }
             push( @{ $self->{buffer} }, $sample );
         }
-        
+
         $self->_send_one_sample() while @{ $self->{buffer} } >= ( $self->{normal_fade_seconds} * $self->{sample_rate} );
 
         if ( !( $self->{elapsed} % $self->{sample_rate} )
@@ -220,27 +226,37 @@ sub _send_one_sample {
     my $self   = shift;
     my $sample = shift @{ $self->{buffer} };
     my $fh     = $self->{out_fh};
-    print $fh map { pack 's*', $_ } @$sample;
+
+    if ( ref $sample eq 'ARRAY' ) {
+        print $fh map { pack 's*', $_ } @$sample;
+    } else {
+        print $fh $sample;
+    }
+}
+
+sub _unpack_sample {
+    my ($self, $sample) = @_;
+
+    return $sample unless defined $sample;
+    return $sample if ref $sample eq 'ARRAY';
+    return [unpack 's*', $sample];
 }
 
 sub _get_sample {
     my $self = shift;
-    return undef if eof( $self->{source} );
+
     my $data;
-    read( $self->{source}, $data, $self->{channels_amount} * 2 );
+    my $len = read( $self->{source}, $data, $self->{channels_amount} * 2 );
+
+    return undef if $len == 0;
     $self->{elapsed}++;
 
-    if ( length($data) == ( $self->{channels_amount} * 2 ) ) {
-        my @sample;
-        while ( length($data) ) {
-            my $bytes_this_sample = substr( $data, 0, $self->{channels_amount} * 2, '' );
-            push( @sample, unpack 's*', $bytes_this_sample );
-        }
-        return \@sample;
-    } else {
-        my @sample = (0) x ( $self->{channels_amount} * 2 );
-        return \@sample;
+    if ( $len != ( $self->{channels_amount} * 2 ) ) {
+        # pack's "s" is 16 bit unsigned, so we need two bytes
+        $data = "\x00\x00" x ( $self->{channels_amount} * 2 );
     }
+
+    return $data;
 }
 
 sub _do_get_new_source {
@@ -279,7 +295,7 @@ Audio::StreamGenerator - create a 'radio' stream by mixing ('cross fading') mult
 
     my $out_fh;
     open ($out_fh, '|-', $out_command);
-    
+
     sub get_new_source {
         my $fullpath = '/path/to/some/audiofile.flac';
         my @ffmpeg_cmd = (
@@ -296,7 +312,7 @@ Audio::StreamGenerator - create a 'radio' stream by mixing ('cross fading') mult
         open(my $source, '-|', @ffmpeg_cmd);
         return $source;
     }
-    
+
     sub run_every_second {
         my $streamert = shift;
         my $position = $streamert->get_elapsed_seconds();
@@ -305,30 +321,30 @@ Audio::StreamGenerator - create a 'radio' stream by mixing ('cross fading') mult
             $streamert->skip()
         }
     }
-    
+
     my $streamer = Audio::StreamGenerator->new(
         out_fh => $out_fh,
         get_new_source => \&get_new_source,
         run_every_second => \&run_every_second,
     );
-    
+
     $streamer->stream();
 
 =head1 DESCRIPTION
 
-This module creates a 'live' audio stream that can be broadcast using streaming technologies like Icecast or HTTP Live Streaming. 
+This module creates a 'live' audio stream that can be broadcast using streaming technologies like Icecast or HTTP Live Streaming.
 
-It creates one ongoing audio stream by mixing or 'crossfading' multiple sources (normally audio files). 
+It creates one ongoing audio stream by mixing or 'crossfading' multiple sources (normally audio files).
 
-Although there is nothing stopping you from using this to generate a file that can be played back later, its intended use is to create a 'radio' stream that can be streamed or 'broadcast' live on the internet. 
+Although there is nothing stopping you from using this to generate a file that can be played back later, its intended use is to create a 'radio' stream that can be streamed or 'broadcast' live on the internet.
 
-The module takes raw PCM audio from a file handle as input, and outputs raw PCM audio to another file handle. This means that an external program is necessary to decode (mp3/flac/etc) source files, and to encode & stream the actual output. For both purposes, ffmpeg is recommended - but anything that can produce and/or receive raw PCM audio should do. 
+The module takes raw PCM audio from a file handle as input, and outputs raw PCM audio to another file handle. This means that an external program is necessary to decode (mp3/flac/etc) source files, and to encode & stream the actual output. For both purposes, ffmpeg is recommended - but anything that can produce and/or receive raw PCM audio should do.
 
 =head1 CONSTRUCTOR METHOD
 
     my $streamer = Audio::StreamGenerator->new( %options );
 
-Creates a new StreamGenerator object and returns it. 
+Creates a new StreamGenerator object and returns it.
 
 =head1 OPTIONS
 
@@ -347,16 +363,16 @@ The following options can be specified:
 
 =head2 out_fh
 
-The outgoing file handle - this is where the generated signed 16-bit little-endian PCM audio stream is sent to. 
+The outgoing file handle - this is where the generated signed 16-bit little-endian PCM audio stream is sent to.
 
-Note that StreamGenerator has no notion of time - if you don't slow it down, it will process data as fast as it can - which is faster than your listeners are able to play the stream. 
-On Icecast, this will cause listeners to be disconnected because they are "too far behind". 
+Note that StreamGenerator has no notion of time - if you don't slow it down, it will process data as fast as it can - which is faster than your listeners are able to play the stream.
+On Icecast, this will cause listeners to be disconnected because they are "too far behind".
 
-This can be addressed by making sure that the out_fh process consumes the audio no faster than realtime. 
+This can be addressed by making sure that the out_fh process consumes the audio no faster than realtime.
 
-If you are using ffmpeg, you can achieve this with its '-re' option. 
+If you are using ffmpeg, you can achieve this with its '-re' option.
 
-Another possibility is to first pipe the data to a command like 'pv' to rate limit the data. An additional advantage of 'pv' is that it can also add a buffer between the StreamGenerator and the encoder, which can absorb any short delays that may occur when StreamGenerator is switching to a new track. 
+Another possibility is to first pipe the data to a command like 'pv' to rate limit the data. An additional advantage of 'pv' is that it can also add a buffer between the StreamGenerator and the encoder, which can absorb any short delays that may occur when StreamGenerator is switching to a new track.
 
 Example:
 
@@ -364,36 +380,36 @@ Example:
 
 This will tell pv to be quiet (no output to STDERR), to allow a maximum throughput of 44100 samples per second * 2 bytes per sample * 2 channels = 176400 bytes per second, and keep a buffer of 176400 Bps * 20 seconds = 3528000 bytes
 
-The out_fh command is also the place where you could insert a sound processing solution like the command line version of L<Stereo tool|https://www.stereotool.com/> - just pipe the audio first to that tool, and from there to your encoder. 
+The out_fh command is also the place where you could insert a sound processing solution like the command line version of L<Stereo tool|https://www.stereotool.com/> - just pipe the audio first to that tool, and from there to your encoder.
 
 =head2 get_new_source
 
-Reference to a sub that will be called every time that a new source (audio file) is needed. Needs to return a readable filehandle that will output signed 16-bit little-endian PCM audio. 
-    
+Reference to a sub that will be called every time that a new source (audio file) is needed. Needs to return a readable filehandle that will output signed 16-bit little-endian PCM audio.
+
 =head2 run_every_second
 
-This sub will be run after each second of playback, with the StreamGenerator object as an argument. This can be used to do things like updating a UI with the current playing position - or to call the skip() method if we need to skip to the next source. 
-    
+This sub will be run after each second of playback, with the StreamGenerator object as an argument. This can be used to do things like updating a UI with the current playing position - or to call the skip() method if we need to skip to the next source.
+
 =head2 normal_fade_seconds
 
 Amount of seconds that we want tracks to overlap. This is only the initial/max value - the mixing algorithm may decide to mix less seconds if the old track ends with loud samples.
-    
+
 =head2 skip_fade_seconds
 
-When 'skipping' to the next song using the skip() method (for example, after a user clicked a "next song" button on some web interface), we mix less seconds than normally, simply because mixing 5+ seconds in the middle of the old track sounds pretty bad. This value has to be lower than normal_fade_seconds. 
-    
+When 'skipping' to the next song using the skip() method (for example, after a user clicked a "next song" button on some web interface), we mix less seconds than normally, simply because mixing 5+ seconds in the middle of the old track sounds pretty bad. This value has to be lower than normal_fade_seconds.
+
 =head2 sample_rate
 
-The amount of samples per second (both incoming & outgoing), normally this is 44100 for standard CD-quality audio. 
-    
+The amount of samples per second (both incoming & outgoing), normally this is 44100 for standard CD-quality audio.
+
 =head2 channels_amount
 
-Amount of audio channels, this is normally 2 (stereo). 
+Amount of audio channels, this is normally 2 (stereo).
 
 =head2 max_vol_before_mix_fraction
 
-This tells StreamGenerator what the minimum volume of a 'loud' sample is. It is expressed as a fraction of the maximum volume. 
-When mixing 2 tracks, StreamGenerator needs to find out what the last loud sample of the old track is so that it can start the next song immediately after that. 
+This tells StreamGenerator what the minimum volume of a 'loud' sample is. It is expressed as a fraction of the maximum volume.
+When mixing 2 tracks, StreamGenerator needs to find out what the last loud sample of the old track is so that it can start the next song immediately after that.
 
 =head1 METHODS
 
@@ -407,18 +423,18 @@ Start the actual audio stream.
 
     $streamer->skip();
 
-Skip to the next track without finishing the current one. This can be called from the "run_every_second" sub, for example after checking whether a 'skip' flag was set in a database, or whether a file exists. 
+Skip to the next track without finishing the current one. This can be called from the "run_every_second" sub, for example after checking whether a 'skip' flag was set in a database, or whether a file exists.
 
 =head2 get_elapsed_samples
 
     my $elapsed_samples = $streamer->get_elapsed_samples();
     print "$elapsed_samples played so far\r";
 
-Get the amount of played samples in the current track - this can be called from the "run_every_second" sub. 
+Get the amount of played samples in the current track - this can be called from the "run_every_second" sub.
 
 =head2 get_elapsed_seconds
 
     my $elapsed_seconds = $streamer->get_elapsed_seconds();
     print "now at position $elapsed_seconds of the current track\r";
 
-Get the amount of elapsed seconds in the current track - in other words the current position in the track. This equals to get_elapsed_samples/sample_rate . 
+Get the amount of elapsed seconds in the current track - in other words the current position in the track. This equals to get_elapsed_samples/sample_rate .

--- a/lib/Audio/StreamGenerator.pm
+++ b/lib/Audio/StreamGenerator.pm
@@ -175,10 +175,9 @@ sub stream {
 
             push( @{ $self->{buffer} }, @new_buffer );
 
-            my $channel = 0;
 
             # Volume adjustment
-            foreach my $channel ( grep { $max[$channel] > $maxint } @channels ) {
+            foreach my $channel ( grep { $max[$_] > $maxint } @channels ) {
                 $logger->info("channel $channel needs volume adjustment");
 
                 foreach my $sample ( @{ $self->{buffer} } ) {

--- a/lib/Audio/StreamGenerator.pm
+++ b/lib/Audio/StreamGenerator.pm
@@ -201,9 +201,7 @@ sub stream {
 
         $self->_send_one_sample() while @{ $self->{buffer} } >= ( $self->{normal_fade_seconds} * $self->{sample_rate} );
 
-        if ( !( $self->{elapsed} % $self->{sample_rate} )
-            && defined( $self->{run_every_second} ) )
-        {
+        if ( defined( $self->{run_every_second} ) && !( $self->{elapsed} % $self->{sample_rate} )) {
             $self->{run_every_second}($self);
         }
 

--- a/lib/Audio/StreamGenerator.pm
+++ b/lib/Audio/StreamGenerator.pm
@@ -242,14 +242,15 @@ sub _get_sample {
     my $self = shift;
 
     my $data;
-    my $len = read( $self->{source}, $data, $self->{channels_amount} * 2 );
+    my $bytes = $self->{channels_amount} * 2;
+    my $len   = read( $self->{source}, $data, $bytes );
 
     return undef if $len == 0;
     $self->{elapsed}++;
 
-    if ( $len != ( $self->{channels_amount} * 2 ) ) {
+    if ( $len != $bytes ) {
         # pack's "s" is 16 bit unsigned, so we need two bytes
-        $data = "\x00\x00" x ( $self->{channels_amount} * 2 );
+        $data = "\x00\x00" x $bytes ;
     }
 
     return $data;


### PR DESCRIPTION
This is my attempt to reduce CPU usage. Resolves #1 

Performance gains mainly due to almost complete removal of `eof` calls, as well as on-demand sample unpacking.
Only when mixing is required, contents of the buffer will be unpacked. Otherwise they are simply passed from handle to handle in string form. `_send_one_sample` checks whether it should pack the sample or not.

On my VPS, CPU usage of the perl process seem to have dropped to 16-19%, from 23-26% before the optimization. That's 17 - 38% speedup, however during mixing CPU usage jumps to 30% briefly to catch up with non-unpacked data, so the real number is a bit lower.

I see no side effects on my machine, but would be good if you could take a look and test yourself.