### PR TITLE
Maintenance: version number, changelog

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,0 +1,5 @@
+Revision history for Perl extension Audio::StreamGenerator.
+
+1.00 Wed Sep 21 2022
+	- First stable version
+

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension Audio::StreamGenerator.
 
+1.01 Wed Sep 21 2022
+	- Fix version numbering to always have the same length
+
 1.00 Wed Sep 21 2022
 	- First stable version
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,5 +1,7 @@
 lib/Audio/StreamGenerator.pm
+Changes
 LICENSE
 Makefile.PL
 MANIFEST			This list of files
 README.md
+

--- a/lib/Audio/StreamGenerator.pm
+++ b/lib/Audio/StreamGenerator.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = 1.00;
+our $VERSION = '1.00';
 
 use constant {
     MAXINT => 32767

--- a/lib/Audio/StreamGenerator.pm
+++ b/lib/Audio/StreamGenerator.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = '1.00';
+our $VERSION = '1.01';
 
 use constant {
     MAXINT => 32767


### PR DESCRIPTION
I did not catch this ealier, but the version number in `our $VERSION` must be a string. The value `1.00` (as a number) got interpreted as just `1`. Its best to keep version numbers the same length, so string is a must.

I also added a changelog. Metacpan will read the changelog automatically and in general its good to have one.

I've seen you granted me a co-maintaner on CPAN, so I can make a release after the MR is merged.