### PR TITLE
Splas/skip silence at begin of track

### DIFF
--- a/lib/Audio/StreamGenerator.pm
+++ b/lib/Audio/StreamGenerator.pm
@@ -48,14 +48,8 @@ sub new {
     my %key_lookup = map { $_ => 1 } ( @mandatory_keys, keys %self );
 
     foreach my $key ( keys %args ) {
-        croak "unknown argument '$key'"
-            if !defined( $key_lookup{$key} );
-    }
-
-    foreach my $key (keys %key_lookup) {
-        if (exists $args{$key}) {
-            $self{$key} = $args{$key}
-        }
+        croak "unknown argument '$key'" if !defined( $key_lookup{$key} );
+        $self{$key} = $args{$key}
     }
 
     bless \%self, $class;

--- a/lib/Audio/StreamGenerator.pm
+++ b/lib/Audio/StreamGenerator.pm
@@ -611,7 +611,7 @@ If enabled, audio softer than L</"min_audible_vol_fraction"> at the beginning of
 
 =head2 min_audible_vol_fraction
 
-Audio softer than this volume fraction at the end of a track (and within the buffer) will be skipped, if skip_silence is enabled.
+Audio softer than this volume fraction at the end of a track (and within the buffer) or at the beginning of a track will be skipped, if skip_silence is enabled.
 
 =head2 debug
 


### PR DESCRIPTION
- Add some logic to skip silence at the beginning of a track, much like we do at the end of tracks. 
- Add constructor option to disable silence removal completely in case a user wants to be able to stream silence.
- While working on this, I found out that the constructor logic was badly broken - it did not accept any of the documented custom options. This should be fixed now. 
- Add documentation for new `skip_silence` option
- Add/repair some links between sections in the pod. 
- The `debug` method is not part of the public API, so renaming it to `_debug`.

@bbrtj could you take a look at this please? The silence removal part probably affects the way you are using the module? 

I think it's probably reasonable to have it on by default (and it was already happening for end of track silence) , but let me know if you disagree :)